### PR TITLE
Enforce retry_wait_seconds both when command fails and times out

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,19 +18,20 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm ci
-      - name: Test
-        uses: ./
-        continue-on-error: true
-        with:
-          timeout_minutes: 1
-          max_attempts: 3
-          command: npm install this-isnt-a-real-package-name-zzz
       - name: happy-path
         uses: ./
         with:
           timeout_minutes: 1
           max_attempts: 2
           command: npm -v
+      - name: sad-path (retry_wait_seconds)
+        uses: ./
+        continue-on-error: true
+        with:
+          timeout_minutes: 1
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: npm install this-isnt-a-real-package-name-zzz
       - name: sad-path (error)
         uses: ./
         continue-on-error: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -461,16 +461,21 @@ async function runCmd() {
 
   if (!done) {
     kill(child.pid);
-    const waitStart = Date.now();
-    await wait(ms.seconds(RETRY_WAIT_SECONDS));
-    debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
-    debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
+    await retryWait();
     throw new Error(`Timeout of ${TIMEOUT_MINUTES}m hit`);
   } else if (exit > 0) {
+    await retryWait();
     throw new Error(`Child_process exited with error`);
   } else {
     return;
   }
+}
+
+async function retryWait() {
+  const waitStart = Date.now();
+  await wait(ms.seconds(RETRY_WAIT_SECONDS));
+  debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
+  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
 }
 
 async function runAction() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -474,8 +474,8 @@ async function runCmd() {
 async function retryWait() {
   const waitStart = Date.now();
   await wait(ms.seconds(RETRY_WAIT_SECONDS));
-  debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
-  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
+  debug(`Waited ${Date.now() - waitStart}ms`);
+  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}ms`);
 }
 
 async function runAction() {

--- a/src/index.js
+++ b/src/index.js
@@ -45,16 +45,21 @@ async function runCmd() {
 
   if (!done) {
     kill(child.pid);
-    const waitStart = Date.now();
-    await wait(ms.seconds(RETRY_WAIT_SECONDS));
-    debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
-    debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
+    await retryWait();
     throw new Error(`Timeout of ${TIMEOUT_MINUTES}m hit`);
   } else if (exit > 0) {
+    await retryWait();
     throw new Error(`Child_process exited with error`);
   } else {
     return;
   }
+}
+
+async function retryWait() {
+  const waitStart = Date.now();
+  await wait(ms.seconds(RETRY_WAIT_SECONDS));
+  debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
+  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
 }
 
 async function runAction() {

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ async function runCmd() {
 async function retryWait() {
   const waitStart = Date.now();
   await wait(ms.seconds(RETRY_WAIT_SECONDS));
-  debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
-  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
+  debug(`Waited ${Date.now() - waitStart}ms`);
+  debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}ms`);
 }
 
 async function runAction() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { getInput, error, warning, info } = require('@actions/core');
+const { getInput, error, warning, info, debug } = require('@actions/core');
 const { spawn } = require('child_process');
 const { join } = require('path');
 const ms = require('milliseconds');
@@ -23,7 +23,7 @@ const RETRY_WAIT_SECONDS = getInputNumber('retry_wait_seconds', false);
 const POLLING_INTERVAL_SECONDS = getInputNumber('polling_interval_seconds', false);
 
 async function wait(ms) {
-  return new Promise(r => setTimeout(r, ms));
+  return new Promise((r) => setTimeout(r, ms));
 }
 
 async function runCmd() {
@@ -32,7 +32,7 @@ async function runCmd() {
 
   var child = spawn('node', [join(__dirname, 'exec.js'), COMMAND], { stdio: 'inherit' });
 
-  child.on('exit', code => {
+  child.on('exit', (code) => {
     if (code > 0) {
       exit = code;
     }
@@ -45,7 +45,10 @@ async function runCmd() {
 
   if (!done) {
     kill(child.pid);
+    const waitStart = Date.now();
     await wait(ms.seconds(RETRY_WAIT_SECONDS));
+    debug(`Waited ${ms.seconds(Date.now() - waitStart)}s`);
+    debug(`Configured wait: ${ms.seconds(RETRY_WAIT_SECONDS)}s`);
     throw new Error(`Timeout of ${TIMEOUT_MINUTES}m hit`);
   } else if (exit > 0) {
     throw new Error(`Child_process exited with error`);
@@ -70,7 +73,7 @@ async function runAction() {
   }
 }
 
-runAction().catch(err => {
+runAction().catch((err) => {
   error(err.message);
   process.exit(1);
 });


### PR DESCRIPTION
Fix for Issue #5 reported by @ahansson89

retry_wait_seconds was ignored if spawned process exited with non zero code.  See debug statements showing configured wait time was adhered to: https://github.com/nick-invision/retry/runs/781522755?check_suite_focus=true#step:6:49