### PR TITLE
Add option to suppress warning on retry and fix timeout bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Retries an Action step on failure or timeout. This is currently intended to repl
 
 ### `timeout_minutes`
 
-**Required** Minutes to wait before attempt times out
+**Required** Minutes to wait before attempt times out. Must only specify either minutes or seconds
+
+### `timeout_seconds`
+
+**Required** Seconds to wait before attempt times out. Must only specify either minutes or seconds
 
 ### `max_attempts`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Retries an Action step on failure or timeout. This is currently intended to repl
 
 **Optional** Event to retry on. Currently supports [any (default), timeout, error].
 
+### `warning_on_retry`
+
+**Optional** Whether to output a warning on retry, or just output to info. Defaults to `true`.
+
 ## Outputs
 
 ### `total_attempts`

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     default: 1
   retry_on:
     description: Event to retry on.  Currently supported [any, timeout, error]
+  warning_on_retry:
+    description: Whether to output a warning on retry, or just output to info. Defaults to true
+    default: true
 outputs:
   total_attempts:
     description: The final number of attempts made

--- a/dist/index.js
+++ b/dist/index.js
@@ -292,9 +292,6 @@ function validateInputs() {
             if ((!TIMEOUT_MINUTES && !TIMEOUT_SECONDS) || (TIMEOUT_MINUTES && TIMEOUT_SECONDS)) {
                 throw new Error('Must specify either timeout_minutes or timeout_seconds inputs');
             }
-            if (TIMEOUT_SECONDS && TIMEOUT_SECONDS < RETRY_WAIT_SECONDS) {
-                throw new Error("timeout_seconds " + TIMEOUT_SECONDS + "s less than retry_wait_seconds " + RETRY_WAIT_SECONDS + "s");
-            }
             return [2 /*return*/];
         });
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -251,6 +251,7 @@ var COMMAND = core_1.getInput('command', { required: true });
 var RETRY_WAIT_SECONDS = getInputNumber('retry_wait_seconds', false) || 10;
 var POLLING_INTERVAL_SECONDS = getInputNumber('polling_interval_seconds', false) || 1;
 var RETRY_ON = core_1.getInput('retry_on') || 'any';
+var WARNING_ON_RETRY = core_1.getInput('warning_on_retry').toLowerCase() === 'true';
 var OUTPUT_TOTAL_ATTEMPTS_KEY = 'total_attempts';
 var OUTPUT_EXIT_CODE_KEY = 'exit_code';
 var OUTPUT_EXIT_ERROR_KEY = 'exit_error';
@@ -398,7 +399,12 @@ function runAction() {
                         throw error_1;
                     }
                     else {
-                        core_1.warning("Attempt " + attempt + " failed. Reason: " + error_1.message);
+                        if (WARNING_ON_RETRY) {
+                            core_1.warning("Attempt " + attempt + " failed. Reason: " + error_1.message);
+                        }
+                        else {
+                            core_1.info("Attempt " + attempt + " failed. Reason: " + error_1.message);
+                        }
                     }
                     return [3 /*break*/, 6];
                 case 6:

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const COMMAND = getInput('command', { required: true });
 const RETRY_WAIT_SECONDS = getInputNumber('retry_wait_seconds', false) || 10;
 const POLLING_INTERVAL_SECONDS = getInputNumber('polling_interval_seconds', false) || 1;
 const RETRY_ON = getInput('retry_on') || 'any';
+const WARNING_ON_RETRY = getInput('warning_on_retry').toLowerCase() === 'true';
 
 const OUTPUT_TOTAL_ATTEMPTS_KEY = 'total_attempts';
 const OUTPUT_EXIT_CODE_KEY = 'exit_code';
@@ -130,7 +131,11 @@ async function runAction() {
         // error: error
         throw error;
       } else {
-        warning(`Attempt ${attempt} failed. Reason: ${error.message}`);
+        if (WARNING_ON_RETRY) {
+          warning(`Attempt ${attempt} failed. Reason: ${error.message}`);
+        } else {
+          info(`Attempt ${attempt} failed. Reason: ${error.message}`);
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,6 @@ async function validateInputs() {
   if ((!TIMEOUT_MINUTES && !TIMEOUT_SECONDS) || (TIMEOUT_MINUTES && TIMEOUT_SECONDS)) {
     throw new Error('Must specify either timeout_minutes or timeout_seconds inputs');
   }
-
-  if (TIMEOUT_SECONDS && TIMEOUT_SECONDS < RETRY_WAIT_SECONDS) {
-    throw new Error(
-      `timeout_seconds ${TIMEOUT_SECONDS}s less than retry_wait_seconds ${RETRY_WAIT_SECONDS}s`
-    );
-  }
 }
 
 function getTimeout(): number {


### PR DESCRIPTION
To resolve issues #24  and #25, a new `warning_on_retry` input was added (defaults to true) which when false, will only log rather than warn on retry.  Additionally this fixes an issue where timeout_seconds was not allowed to be less than retry_wait_seconds (I still don't know why I did this).