### PR TITLE
Add new_command_on_retry

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -60,6 +60,15 @@ jobs:
           actual: ${{ steps.sad_path_wait_sec.outputs.exit_error }}
           comparison: contains
 
+      - name: new-command-on-retry
+        id: new-command-on-retry
+        uses: ./
+        with:
+          timeout_minutes: 1
+          max_attempts: 3
+          command: node -e "process.exit(1)"
+          new_command_on_retry: node -e "console.log('this is the new command on retry')"
+
       - name: on-retry-cmd
         id: on-retry-cmd
         uses: ./

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Retries an Action step on failure or timeout. This is currently intended to repl
 
 **Optional** Command to run before a retry (such as a cleanup script). Any error thrown from retry command is caught and surfaced as a warning.
 
+### `new_command_on_retry`
+
+**Optional** Command to run if the first attempt fails. This command will be called on all subsequent attempts. 
+
 ### `continue_on_error`
 
 **Optional** Exit successfully even if an error occurs. Same as native continue-on-error behavior, but for use in composite actions. Defaults to `false`
@@ -177,6 +181,17 @@ with:
   max_attempts: 3
   command: npm run some-flaky-script-that-outputs-something
   on_retry_command: npm run cleanup-flaky-script-output
+```
+
+### Run different command after first failure
+
+```yaml
+uses: nick-invision/retry@v2
+with:
+  timeout_seconds: 15
+  max_attempts: 3
+  command: npx jest
+  new_command_on_retry: npx jest --onlyFailures 
 ```
 
 ### Run multi-line, multi-command script

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Retries an Action step on failure or timeout. This is currently intended to repl
 
 ### `new_command_on_retry`
 
-**Optional** Command to run if the first attempt fails. This command will be called on all subsequent attempts. 
+**Optional** Command to run if the first attempt fails. This command will be called on all subsequent attempts.
 
 ### `continue_on_error`
 
@@ -191,7 +191,7 @@ with:
   timeout_seconds: 15
   max_attempts: 3
   command: npx jest
-  new_command_on_retry: npx jest --onlyFailures 
+  new_command_on_retry: npx jest --onlyFailures
 ```
 
 ### Run multi-line, multi-command script

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   continue_on_error:
     description: Exits successfully even if an error occurs.  Same as native continue-on-error behavior, but for use in composite actions. Default is false
     default: false
+  new_command_on_retry:
+    description: Command to run if the first attempt fails. This command will be called on all subsequent attempts.
+    required: false
 outputs:
   total_attempts:
     description: The final number of attempts made

--- a/dist/index.js
+++ b/dist/index.js
@@ -288,6 +288,7 @@ var RETRY_ON = core_1.getInput('retry_on') || 'any';
 var WARNING_ON_RETRY = core_1.getInput('warning_on_retry').toLowerCase() === 'true';
 var ON_RETRY_COMMAND = core_1.getInput('on_retry_command');
 var CONTINUE_ON_ERROR = getInputBoolean('continue_on_error');
+var NEW_COMMAND_ON_RETRY = core_1.getInput('new_command_on_retry');
 var OS = process.platform;
 var OUTPUT_TOTAL_ATTEMPTS_KEY = 'total_attempts';
 var OUTPUT_EXIT_CODE_KEY = 'exit_code';
@@ -408,7 +409,7 @@ function runRetryCmd() {
         });
     });
 }
-function runCmd() {
+function runCmd(attempt) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function () {
         var end_time, executable, child;
@@ -420,7 +421,9 @@ function runCmd() {
                     exit = 0;
                     done = false;
                     core_1.debug("Running command " + COMMAND + " on " + OS + " using shell " + executable);
-                    child = child_process_1.exec(COMMAND, { 'shell': executable });
+                    child = attempt > 1 && NEW_COMMAND_ON_RETRY
+                        ? child_process_1.exec(NEW_COMMAND_ON_RETRY, { 'shell': executable })
+                        : child_process_1.exec(COMMAND, { 'shell': executable });
                     (_a = child.stdout) === null || _a === void 0 ? void 0 : _a.on('data', function (data) {
                         process.stdout.write(data);
                     });
@@ -482,7 +485,7 @@ function runAction() {
                     _a.trys.push([3, 5, , 11]);
                     // just keep overwriting attempts output
                     core_1.setOutput(OUTPUT_TOTAL_ATTEMPTS_KEY, attempt);
-                    return [4 /*yield*/, runCmd()];
+                    return [4 /*yield*/, runCmd(attempt)];
                 case 4:
                     _a.sent();
                     core_1.info("Command completed after " + attempt + " attempt(s).");


### PR DESCRIPTION
This PR adds a new feature called `new_command_on_retry`. This is an optional input that will be used on subsequent attempts if the first attempt fails.

Example use case:
1. Step calls `npx jest`
2. Flaky test fails
3. Need to rerun `npx jest` but don't want to run all jests again
4. To prevent running all tests again, want to run with `--onlyFailures` flag