### PR TITLE
Update v3 to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The final error returned by the command
 ### Shell
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_minutes: 10
   max_attempts: 3
@@ -88,7 +88,7 @@ with:
 ### Timeout in minutes
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_minutes: 10
   max_attempts: 3
@@ -98,7 +98,7 @@ with:
 ### Timeout in seconds
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_seconds: 15
   max_attempts: 3
@@ -108,7 +108,7 @@ with:
 ### Only retry after timeout
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_seconds: 15
   max_attempts: 3
@@ -119,7 +119,7 @@ with:
 ### Only retry after error
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_seconds: 15
   max_attempts: 3
@@ -130,7 +130,7 @@ with:
 ### Retry using continue_on_error input (in composite action) but allow failure and do something with output
 
 ```yaml
-- uses: nick-fields/retry@v3
+- uses: nick-fields/retry@v4
   id: retry
   with:
     timeout_seconds: 15
@@ -152,7 +152,7 @@ with:
 ### Retry using continue-on-error built-in command (in workflow action) but allow failure and do something with output
 
 ```yaml
-- uses: nick-fields/retry@v3
+- uses: nick-fields/retry@v4
   id: retry
   # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
   continue-on-error: true
@@ -181,7 +181,7 @@ with:
 ### Run script after failure but before retry
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_seconds: 15
   max_attempts: 3
@@ -192,7 +192,7 @@ with:
 ### Run different command after first failure
 
 ```yaml
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_seconds: 15
   max_attempts: 3
@@ -204,7 +204,7 @@ with:
 
 ```yaml
 name: Multi-line multi-command Test
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_minutes: 1
   max_attempts: 2
@@ -217,7 +217,7 @@ with:
 
 ```yaml
 name: Multi-line single-command Test
-uses: nick-fields/retry@v3
+uses: nick-fields/retry@v4
 with:
   timeout_minutes: 1
   max_attempts: 2


### PR DESCRIPTION
Updating version to v4 as version 3 uses Node version 20, which is deprecated.
