### PR TITLE
Bump `ci_cd` workflow actions (node24 compatibility)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
       - name: Run Unit Tests
         run: npm test
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           directory: ./coverage/
           verbose: true
@@ -48,7 +48,7 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: npm -v
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: true
           actual: ${{ steps.happy_path.outputs.total_attempts == '1' && steps.happy_path.outputs.exit_code == '0' }}
@@ -67,11 +67,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: node -e "process.exit(1)"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.sad_path_error.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.sad_path_error.outcome }}
@@ -85,15 +85,15 @@ jobs:
           max_attempts: 3
           retry_on: timeout
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 1
           actual: ${{ steps.retry_on_timeout_fail.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_timeout_fail.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.retry_on_timeout_fail.outputs.exit_code }}
@@ -107,15 +107,15 @@ jobs:
           max_attempts: 2
           retry_on: error
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.retry_on_error.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_error.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.retry_on_error.outputs.exit_code }}
@@ -129,11 +129,11 @@ jobs:
           max_attempts: 2
           shell: cmd
           command: 'dir'
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.wrong_shell.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.wrong_shell.outcome }}
@@ -180,12 +180,12 @@ jobs:
           timeout_minutes: 5
           command: 'make -C ./test-data/large-output bytes-102400'
       - name: Assert test had expected result
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.large-output.outcome }}
       - name: Assert exit code is expected
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.large-output.outputs.exit_code }}
@@ -211,11 +211,11 @@ jobs:
           retry_on_exit_code: 2
           max_attempts: 3
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_exit_code_expected.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 3
           actual: ${{ steps.retry_on_exit_code_expected.outputs.total_attempts }}
@@ -229,11 +229,11 @@ jobs:
           retry_on_exit_code: 2
           max_attempts: 3
           command: node -e "process.exit(1)"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_exit_code_unexpected.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 1
           actual: ${{ steps.retry_on_exit_code_unexpected.outputs.total_attempts }}
@@ -265,22 +265,22 @@ jobs:
           timeout_minutes: 1
           continue_on_error: true
       - name: Verify continue_on_error returns correct exit code on success
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: 0
           actual: ${{ steps.happy_path_continue_on_error.outputs.exit_code }}
       - name: Verify continue_on_error exits with correct outcome on success
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: success
           actual: ${{ steps.happy_path_continue_on_error.outcome }}
       - name: Verify continue_on_error returns correct exit code on error
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: 33
           actual: ${{ steps.sad_path_continue_on_error.outputs.exit_code }}
       - name: Verify continue_on_error exits with successful outcome when an error occurs
-        uses: nick-fields/assert-action@v2
+        uses: nick-fields/assert-action@v4
         with:
           expected: success
           actual: ${{ steps.sad_path_continue_on_error.outcome }}
@@ -307,15 +307,15 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           command: npm install this-isnt-a-real-package-name-zzz
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 3
           actual: ${{ steps.sad_path_wait_sec.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.sad_path_wait_sec.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 'Final attempt failed'
           actual: ${{ steps.sad_path_wait_sec.outputs.exit_error }}
@@ -385,11 +385,11 @@ jobs:
           timeout_seconds: 15
           max_attempts: 2
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.sad_path_timeout.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.sad_path_timeout.outcome }}
@@ -416,11 +416,11 @@ jobs:
           max_attempts: 2
           retry_on: timeout
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.retry_on_timeout.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_timeout.outcome }}
@@ -447,15 +447,15 @@ jobs:
           max_attempts: 2
           retry_on: error
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 1
           actual: ${{ steps.retry_on_error_fail.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.retry_on_error_fail.outcome }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 1
           actual: ${{ steps.retry_on_error_fail.outputs.exit_code }}
@@ -481,11 +481,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: 2
           actual: ${{ steps.sad_path_timeout_minutes.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@v4
         with:
           expected: failure
           actual: ${{ steps.sad_path_timeout_minutes.outcome }}


### PR DESCRIPTION
_Replace the bullet points below with your answers_

### Description

Bump `ci_cd` workflow actions (node24 compatibility)

* `nick-fields/assert-action` to `v4` https://github.com/nick-fields/assert-action/releases

* `codecov/codecov-action` to `v7` https://github.com/codecov/codecov-action/releases


### Testing

- What tests were added?
  None
